### PR TITLE
put source locations on set expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/compiled/*
+**/doc/*
+**/*~
 **/*.bak
 **/*.html
 **/*.css

--- a/set-exp/lang/reader.rkt
+++ b/set-exp/lang/reader.rkt
@@ -14,7 +14,11 @@
                            (define s (read-syntax/recursive src in ch #f))
                            (syntax-case s ()
                              [(item ...)
-                              (datum->syntax s (cons 'set (syntax-e s)))])))))
+                              (datum->syntax
+                               s
+                               (cons 'set (syntax-e s))
+                               s
+                               s)])))))
     (lambda (in rd stx?)
       (parameterize ((current-readtable send-readtable))
 	(if stx?


### PR DESCRIPTION
This makes it so that the syntax object for `{1 2 3}` reading as `(set 1 2 3)` has the source location from those curly braces.